### PR TITLE
feat(bootloader): Implement bootloader entry conditions

### DIFF
--- a/openblt/src/hal/mod.rs
+++ b/openblt/src/hal/mod.rs
@@ -14,6 +14,10 @@ pub enum HalError {
     CanError,
     #[error("Invalid operation")]
     InvalidOperation,
+    #[error("Programming mode error")]
+    ProgrammingModeError,
+    #[error("Jump error")]
+    JumpError,
 }
 
 pub trait S32KHal {
@@ -30,4 +34,6 @@ pub trait S32KHal {
     fn erase_flash(&mut self, address: u32, length: u32) -> Result<(), Self::Error>;
     fn write_flash(&mut self, address: u32, data: &[u8]) -> Result<(), Self::Error>;
     fn read_flash(&self, address: u32, data: &mut [u8]) -> Result<(), Self::Error>;
+    fn is_programming_pin_active(&self) -> bool;
+    fn jump_to_application(&self, entry_point: u32) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
This commit adds basic bootloader entry conditions and boot flow with the following features:

Entry Conditions:
- Programming pin check (via HAL)
- Application validity check
- CAN programming request check

Application Validation:
- Basic empty check (not all 0xFF)
- Entry point validation (placeholder)
- Checksum validation (placeholder)

Boot Flow:
- Check entry conditions
- Enter programming mode if needed
- Jump to application if valid

HAL Interface:
- Added programming mode control
- Added pin status check
- Added application jump functionality

Note: This is a basic implementation that will be enhanced with:
- More sophisticated application validation
- Additional entry conditions
- Enhanced safety checks
- Better error recovery